### PR TITLE
Mobile fixes

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -25,12 +25,17 @@ body {
     padding-top: 2.2em;
     margin-bottom: 0.5em;
 }
-
 #nav-links {
-    display: inline-block;
-    margin-left: 0.938em;
-    margin-top: 2.2em;
-    position: absolute;
+    margin-left: -1em;
+    margin-top: 0.4em;
+}
+@media (min-width: 756px) {
+  #nav-links {
+      display: inline-block;
+      margin-left: 0.938em;
+      margin-top: 2.2em;
+      position: absolute;
+  }
 }
 
 /* Makes the links purple */

--- a/static/js/angular/stream.js
+++ b/static/js/angular/stream.js
@@ -23,6 +23,10 @@ btvStreamApp.controller("StreamCtrl", function($scope, $http, $interval) {
         $interval(function () {
             $scope.updateValues();
         }, 5000);
+
+        if ($(document).width() < 768) {
+            $scope.chatShown = !$scope.chatShown;
+        }
     };
 
     $scope.toggleChat = function() {


### PR DESCRIPTION
Fixes #1: https://github.com/BronyTV/bronytv.net/issues/1#issuecomment-150070447
- The nav-links should be on it's own line if the width of the screen is smaller than 756px.
- Chat will automatically be hidden on mobile devices (width less than 768px) on page load.
