### PR TITLE
Get current year copyright footer

### DIFF
--- a/btv_site/blueprints/static_pages/static_pages.py
+++ b/btv_site/blueprints/static_pages/static_pages.py
@@ -1,12 +1,13 @@
 from btv_site.utils import site_revision
 from flask import Blueprint, render_template
+from datetime import date
 
 static_pages = Blueprint("static_pages", __name__, template_folder="../templates")
 
 
 @static_pages.context_processor
-def inject_revision():
-    return {"site_revision": site_revision}
+def inject_variables():
+    return {"site_revision": site_revision, "current_year": date.today().year}
 
 
 @static_pages.route("/")

--- a/btv_site/blueprints/templates/layout.html.jinja2
+++ b/btv_site/blueprints/templates/layout.html.jinja2
@@ -36,7 +36,7 @@
             {% block content %}{% endblock %}
             <div class="row">
                 <div class="col-md-10 col-md-offset-1" align="center" id="footer">
-                    <p><a href="/">BronyTV</a> revision <a href="https://github.com/BronyTV/bronytv.net">{{ site_revision }}</a>. Site content &copy; 2011-2016 BronyTV. All rights reserved.</p>
+                    <p><a href="/">BronyTV</a> revision <a href="https://github.com/BronyTV/bronytv.net">{{ site_revision }}</a>. Site content &copy; 2011-{{ current_year }} BronyTV. All rights reserved.</p>
                     <p>My Little Pony: Friendship is Magic is &copy; Hasbro. All creations are &copy; to their respective artists. All songs and videos are property of their respective artists.</p>
                 </div>
             </div>


### PR DESCRIPTION
Have python to import the current year and echo out for the copyright footer. Courtesy of AppleDash. 👍 

(sorry for all this pull requests, i apparently suck at forking 😎 )
