### PR TITLE
Implemented stream viewers count

### DIFF
--- a/alembic/versions/67dae00c4ee8_create_stream_viewers_table.py
+++ b/alembic/versions/67dae00c4ee8_create_stream_viewers_table.py
@@ -1,0 +1,29 @@
+"""Create stream viewers table
+
+Revision ID: 67dae00c4ee8
+Revises: 21b2c9575a84
+Create Date: 2016-07-29 20:29:26.782690
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '67dae00c4ee8'
+down_revision = '21b2c9575a84'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'stream_viewers',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('unique', sa.String(32)),
+        sa.Column('timestamp', sa.TIMESTAMP)
+    )
+
+
+def downgrade():
+    op.drop_table('stream_viewers')

--- a/btv_site/blueprints/templates/index.html.jinja2
+++ b/btv_site/blueprints/templates/index.html.jinja2
@@ -98,6 +98,7 @@
                             <span ng-if="streaming">Now Streaming: <span ng-bind-html="props.now_streaming | unsafe"></span></span>
                             <span ng-if="!streaming">Stream Offline</span>
                         </h3>
+                        <h5 ng-if="streaming">Watching: <span id="viewercounter"></span></h5>
                         <hr>
                     </div>
                     <div class="countdown centered">

--- a/btv_site/blueprints/templates/stream.html.jinja2
+++ b/btv_site/blueprints/templates/stream.html.jinja2
@@ -8,6 +8,7 @@
 
     {% assets "stream_css" %}
         <link rel="stylesheet" href="{{ ASSET_URL }}" />
+        <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
     {% endassets %}
     <script type="text/javascript">
         videojs.options.flash.swf = "/static/swf/video-js.swf";
@@ -21,6 +22,7 @@
                 Stream
                 <span ng-if="streaming">(<span ng-bind-html="properties.now_streaming | unsafe"></span>)</span>
                 <span ng-if="!streaming">(Offline)</span>
+                <span class="pull-right"><i class="fa fa-eye" aria-hidden="true"></i> <span id="viewercounter">1</span></span>
             </h3>
             <div align="center">
                 <div class="aspect-ratio">

--- a/btv_site/models/__init__.py
+++ b/btv_site/models/__init__.py
@@ -1,3 +1,4 @@
 from user import User
 from playlist_item import PlaylistItem
 from site_property import SiteProperty
+from stream_viewer import StreamViewer

--- a/btv_site/models/stream_viewer.py
+++ b/btv_site/models/stream_viewer.py
@@ -1,0 +1,15 @@
+from btv_site.database import db
+
+
+class StreamViewer(db.Model):
+    __tablename__ = "stream_viewers"
+    id = db.Column(db.Integer, primary_key=True)  # Property ID
+    unique = db.Column(db.String(32))             # Client Unique ID
+    timestamp = db.Column(db.TIMESTAMP)           # Timestamp of last request
+
+    def __init__(self, unique, timestamp):
+        self.unique = unique
+        self.timestamp = timestamp
+
+    def __repr__(self):
+        return '<StreamViewer {0} {1} {2}>'.format(self.id, self.unique, self.timestamp)

--- a/static/js/angular/index.js
+++ b/static/js/angular/index.js
@@ -46,6 +46,20 @@ btvIndexApp.controller("CountdownCtrl", function($scope, $http) {
             $scope.time = moment($scope.btvtime).local();
             $scope.target = $scope.props.countdown_target || "The next episode airs";
             $scope.done = $scope.props.countdown_done || "It's Pony Time!";
+            $.ajax({
+                url: '/api/viewercount',
+                type: 'GET',
+                success: function(json) {
+                  if ($scope.streaming) {
+                    document.getElementById("viewercounter").innerHTML = json["viewercount"];
+                  }
+                },
+                error: function() {
+                  if ($scope.streaming) {
+                    document.getElementById("viewercounter").innerHTML = "Error fetching the current view count.";
+                  }
+                }
+            });
         });
     };
 

--- a/static/js/angular/stream.js
+++ b/static/js/angular/stream.js
@@ -76,11 +76,25 @@ btvStreamApp.controller("StreamCtrl", function($scope, $http, $interval) {
             };
         });
     };
+    $scope.updateCounter = function() {
+      $.ajax({
+          url: '/api/viewercount',
+          type: 'POST',
+          success: function(json) {
+            document.getElementById("viewercounter").innerHTML = json["viewercount"];
+          },
+          error: function() {
+            document.getElementById("viewercounter").innerHTML = "-1";
+          }
+      });
+    };
     $scope.init = function() {
         $scope.updateValues();
+        $scope.updateCounter();
 
         $interval(function () {
             $scope.updateValues();
+            $scope.updateCounter();
         }, 5000);
     };
 


### PR DESCRIPTION
- View the count at the home page sidebar (if the person is streaming) or at the stream page
- Database change- new table to keep track of all unique users
- Send a POST request to update the count
- Send a GET request to see the count
- If client doesn't send POST request in 10 seconds, it doesn't get tracked in the count
- Unique identification string stored inside of session cookie

...thats about it, i think...
