### PR TITLE
Cache to consider request values

### DIFF
--- a/btv_site/blueprints/api/api.py
+++ b/btv_site/blueprints/api/api.py
@@ -137,7 +137,7 @@ def api_viewercount_post():
 
 
 @api.route("/schedule", methods=["GET"])
-@cached(timeout=300)
+@cached(timeout=300, requestvals=["tzoffset", "offsettoday", "maxresults"])
 def api_schedule_get():
     tzoffset = urllib.quote_plus(request.args.get('tzoffset', "-08:00")).replace("+", "%2B") #Pacific Standard Time for the win
     offsettoday = int(float(str(request.args.get('offsettoday', 0))))
@@ -161,7 +161,7 @@ def api_schedule_get():
     return jsonify(events=events)
 
 @api.route("/event", methods=["GET"])
-@cached(timeout=300)
+@cached(timeout=300, requestvals=["tzoffset", "eventid"])
 def api_event_get():
     tzoffset = urllib.quote_plus(request.args.get('tzoffset', "-08:00")).replace("+", "%2B") #Pacific Standard Time for the win
     eventid = request.args.get('eventid', 0)

--- a/btv_site/decorators.py
+++ b/btv_site/decorators.py
@@ -38,11 +38,15 @@ def add_response_headers(headers=None):
     return decorator
 
 
-def cached(timeout=5 * 60, key='view/%s'):
+def cached(timeout=5 * 60, key='view/%s', requestvals=[]):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             cache_key = key % request.path
+            if len(requestvals) > 0:
+                cache_key += "/"
+                for val in requestvals:
+                    cache_key += val + "=" + request.values.get(val, "") + "&"
             rv = cache.get(cache_key)
             if rv is not None:
                 return rv
@@ -51,4 +55,3 @@ def cached(timeout=5 * 60, key='view/%s'):
             return rv
         return decorated_function
     return decorator
-


### PR DESCRIPTION
so like the first person who clicks on the random pony media event will see the event again if they click no hooves barred within the 5 mins of cache
This is a problem, and I propose this fix for the cache to consider the request values and uses these as a part of the cache key.
That way, each individual events are cached, not the whole event endpoint.