### PR TITLE
Force showing focus message for chat on the stream page

### DIFF
--- a/btv_site/blueprints/templates/stream.html.jinja2
+++ b/btv_site/blueprints/templates/stream.html.jinja2
@@ -43,7 +43,7 @@
                 <h3>Chat</h3>
                 <div class="chat-aspect-ratio">
                     <iframe id="chat" scrolling="yes" frameborder="no"
-                        src="https://titanembeds.tk/embed/81387914189078528"></iframe>
+                        src="https://titanembeds.tk/embed/81387914189078528?forcefocus=1"></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Titan recently had a tad bit complaints with this focus message. So instead I made it optional unless forced. The primary reason why the message exists is that it automatically logs the user in when the iframe is loaded.
So in BTV's sense, sometimes users (like me) use the chat pop up instead of using the embed on the side of the stream. Because there is a rate limiter going on, the popup chat and the embed chat would probably hit the rate limit sometime during its message fetching (as both are simultaneously making requests for messages). Currently, it has been set to 2 requests per second, but it did hit the rate limit from time to time for some unknown reasons...
The chat embed is set a while ago to not be visible defaulted. This query parameter forces the focus message to show for the chat embed, so it doesn't start making requests until the user has _told it to do so_.