### PR TITLE
Optimize viewercounter

### DIFF
--- a/btv_site/blueprints/api/api.py
+++ b/btv_site/blueprints/api/api.py
@@ -114,11 +114,14 @@ def api_raribox_post():
     db.session.commit()
     return jsonify({"error": False})
 
-@api.route("/viewercount", methods=["GET"])
-def api_viewercount_get():
+def get_viewercount():
     time_past = (datetime.datetime.now() - datetime.timedelta(seconds = 10)).strftime('%Y-%m-%d %H:%M:%S')
     viewerquery = db.session.query(StreamViewer).filter(StreamViewer.timestamp > time_past).all()
-    return jsonify(viewercount=len(viewerquery))
+    return len(viewerquery)
+
+@api.route("/viewercount", methods=["GET"])
+def api_viewercount_get():
+    return jsonify(viewercount=get_viewercount())
 
 @api.route("/viewercount", methods=["POST"])
 def api_viewercount_post():
@@ -133,7 +136,7 @@ def api_viewercount_post():
     else:
         viewerquery.timestamp = time_now
         db.session.commit()
-    return redirect(url_for('api.api_viewercount_get'))
+    return jsonify(viewercount=get_viewercount())
 
 
 @api.route("/schedule", methods=["GET"])

--- a/static/js/angular/stream.js
+++ b/static/js/angular/stream.js
@@ -82,13 +82,11 @@ btvStreamApp.controller("StreamCtrl", function($scope, $http, $interval) {
           type: 'POST',
           success: function(json) {
             document.getElementById("viewercounter").innerHTML = json["viewercount"];
-          },
-          error: function() {
-            document.getElementById("viewercounter").innerHTML = "-1";
           }
       });
     };
     $scope.init = function() {
+        document.getElementById("viewercounter").innerHTML = "-1";
         $scope.updateValues();
         $scope.updateCounter();
 


### PR DESCRIPTION
Instead of telling clients to use GET after POST (resulting in two REST calls), clients will receive the viewer count on the POST call.
In addition, the -1 count will be a thing of the past. If the call to the api fails somehow, the value does not change (therefore showing the user the last successful api call viewer count).